### PR TITLE
DB connection setup & migration flow

### DIFF
--- a/database/db.js
+++ b/database/db.js
@@ -5,6 +5,8 @@ const isLocal = process.env.USE_LOCAL_DB === "true";
 const dbUri = isLocal ? process.env.DB_URI_LOCAL : process.env.DB_URI;
 
 const client = new MongoClient(dbUri, {
+    maxPoolSize: 10,
+    minPoolSize: 2,
     tlsAllowInvalidCertificates: true,
     serverApi: {
       version: ServerApiVersion.v1,

--- a/database/db.js
+++ b/database/db.js
@@ -1,0 +1,36 @@
+const { MongoClient, ServerApiVersion } = require('mongodb');
+require('dotenv').config({path: '../.env'});
+
+const isLocal = process.env.USE_LOCAL_DB === "true";
+const dbUri = isLocal ? process.env.DB_URI_LOCAL : process.env.DB_URI;
+
+const client = new MongoClient(dbUri, {
+    tlsAllowInvalidCertificates: true,
+    serverApi: {
+      version: ServerApiVersion.v1,
+      strict: true,
+      deprecationErrors: true,
+    },
+});
+
+let dbInstance;
+
+async function connectDB() {
+    if (!dbInstance) {
+        try {
+            await client.connect();
+            dbInstance = client.db(process.env.DB_NAME || "SecureRemoteControl"); 
+            console.log("Connected to MongoDB:", dbInstance.databaseName);
+
+        } catch (error) {
+            console.error("MongoDB connection error:", error);
+            throw error;
+        }
+    }
+    return dbInstance;
+}
+
+module.exports = {
+    connectDB,
+    client,
+};

--- a/database/migrate.js
+++ b/database/migrate.js
@@ -24,8 +24,10 @@ async function migrate() {
         await up(db, client); 
 
         console.log("Migrations applied successfully!");
+        process.exit(0);
     } catch (error) {
         console.error("Error during migration:", error);
+        process.exit(1);
     }
 }
 

--- a/database/migrate.js
+++ b/database/migrate.js
@@ -6,8 +6,6 @@ const isLocal = process.env.USE_LOCAL_DB === "true";
 const dbUri = isLocal ? process.env.DB_URI_LOCAL : process.env.DB_URI;
 
 const client = new MongoClient(dbUri, {
-    maxPoolSize: 10,
-    minPoolSize: 2,
     tlsAllowInvalidCertificates: true,
     serverApi: {
         version: ServerApiVersion.v1,

--- a/database/migrate.js
+++ b/database/migrate.js
@@ -1,0 +1,32 @@
+const { MongoClient, ServerApiVersion } = require('mongodb');
+const { up } = require('migrate-mongo');
+require('dotenv').config();
+
+const isLocal = process.env.USE_LOCAL_DB === "true";
+const dbUri = isLocal ? process.env.DB_URI_LOCAL : process.env.DB_URI;
+
+const client = new MongoClient(dbUri, {
+  tlsAllowInvalidCertificates: true,
+  serverApi: {
+    version: ServerApiVersion.v1,
+    strict: true,
+    deprecationErrors: true,
+  },
+});
+
+async function migrate() {
+    try {
+        console.log("Connecting to MongoDB...");
+        await client.connect();
+        const db = client.db(process.env.DB_NAME || "SecureRemoteControl");
+
+        console.log("Running migrations...");
+        await up(db, client); 
+
+        console.log("Migrations applied successfully!");
+    } catch (error) {
+        console.error("Error during migration:", error);
+    }
+}
+
+migrate();

--- a/database/migrate.js
+++ b/database/migrate.js
@@ -6,11 +6,13 @@ const isLocal = process.env.USE_LOCAL_DB === "true";
 const dbUri = isLocal ? process.env.DB_URI_LOCAL : process.env.DB_URI;
 
 const client = new MongoClient(dbUri, {
-  tlsAllowInvalidCertificates: true,
-  serverApi: {
-    version: ServerApiVersion.v1,
-    strict: true,
-    deprecationErrors: true,
+    maxPoolSize: 10,
+    minPoolSize: 2,
+    tlsAllowInvalidCertificates: true,
+    serverApi: {
+        version: ServerApiVersion.v1,
+        strict: true,
+        deprecationErrors: true,
   },
 });
 

--- a/database/migrations/V1__create_devices_collections.js
+++ b/database/migrations/V1__create_devices_collections.js
@@ -1,0 +1,58 @@
+module.exports = {
+    async up(db, client) {
+      await db.createCollection("devices", {
+        validator: {
+          $jsonSchema: {
+            bsonType: "object",
+            required: [
+              "name",
+              "registrationKey",
+            ],
+            properties: {
+              deviceId: {
+                bsonType: "string",
+                description: "Unique device ID"
+              },
+              name: {
+                bsonType: "string",
+                description: "Device name"
+              },
+              model: {
+                bsonType: "string",
+                description: "Device model"
+              },
+              osVersion: {
+                bsonType: "string",
+                description: "Operating system version"
+              },
+              registrationKey: {
+                bsonType: "string",
+                description: "Key used for registering the device"
+              },
+              status: {
+                bsonType: "string",
+                enum: ["active", "inactive", "pending"],
+                description: "Device status"
+              },
+              networkType: {
+                bsonType: "string",
+                enum: ["wifi", "mobileData"],
+                description: "Type of network connection"
+              },
+              ipAddress: {
+                bsonType: "string",
+                pattern: "^([0-9]{1,3}\\.){3}[0-9]{1,3}$",
+                description: "IP address of the device"
+              },
+              lastActiveTime: {
+                bsonType: "date",
+                description: "Last active timestamp"
+              }
+            }
+          }
+        }
+      });
+  
+      console.log("Collections created successfully!");
+    }
+  };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: local-mongo
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+
+volumes:
+  mongodb_data:
+    driver: local

--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -1,0 +1,24 @@
+require('dotenv').config();
+
+const isLocal = process.env.USE_LOCAL_DB === "true";
+const dbUri = isLocal ? process.env.DB_URI_LOCAL : process.env.DB_URI;
+
+const config = {
+  mongodb: {
+    url: dbUri,
+    databaseName: "SecureRemoteControl",
+    options: {
+      useNewUrlParser: true, 
+      useUnifiedTopology: true, 
+    }
+  },
+  migrationsDir: "database/migrations",
+  changelogCollectionName: "changelog",
+  lockCollectionName: "changelog_lock",
+  lockTtl: 0,
+  migrationFileExtension: ".js",
+  useFileHash: false,
+  moduleSystem: 'commonjs',
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -4,14 +4,17 @@
   "description": "Responsible for session management, WebRTC signaling, WebSocket communication, and device registration handling.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node database/migrate.js & node server.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "migrate-mongo": "^12.1.3",
     "ws": "^8.18.1"
   }
 }


### PR DESCRIPTION
db.js used for connection to database, works both for local and prod database. .env file was used to store db_uris. Toggle between prod and local database with .env flag called USE_LOCAL_DB. 
Added a docker compose for running latest mongo version locally.
Used migrate-mongo lib for versioning database changes. 
Initial collection created as per agreement.
migrate.js will run at app start.
For starting your service, you should use npm start from now on.